### PR TITLE
Add Windows support

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -18,3 +18,13 @@ os = "linux"
     [[ROCmDeviceLibs.download]]
     sha256 = "0e0962504aef9ac2aff51623f856caa1ad049f57ecdb455040f53c91b379e2a7"
     url = "https://github.com/JuliaBinaryWrappers/ROCmDeviceLibs_jll.jl/releases/download/ROCmDeviceLibs-v5.6.1+0/ROCmDeviceLibs.v5.6.1.x86_64-linux-musl-cxx11.tar.gz"
+[[ROCmDeviceLibs]]
+arch = "x86_64"
+cxxstring_abi = "cxx11"
+git-tree-sha1 = "5ad5ecb46e3c334821f54c1feecc6c152b7b6a45"
+libc = "mingw32"
+os = "windows"
+
+    [[ROCmDeviceLibs.download]]
+    sha256 = "0e0962504aef9ac2aff51623f856caa1ad049f57ecdb455040f53c91b379e2a7"
+    url = "https://github.com/JuliaBinaryWrappers/ROCmDeviceLibs_jll.jl/releases/download/ROCmDeviceLibs-v5.6.1+0/ROCmDeviceLibs.v5.6.1.x86_64-linux-gnu-cxx11.tar.gz"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ROCmDeviceLibs_jll"
 uuid = "873c0968-716b-5aa7-bb8d-d1e2e2aeff2d"
-version = "5.6.1+0"
+version = "5.6.1+1"
 
 [deps]
 JLLWrappers = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"

--- a/src/ROCmDeviceLibs_jll.jl
+++ b/src/ROCmDeviceLibs_jll.jl
@@ -6,4 +6,5 @@ import JLLWrappers
 
 JLLWrappers.@generate_main_file_header("ROCmDeviceLibs")
 JLLWrappers.@generate_main_file("ROCmDeviceLibs", UUID("873c0968-716b-5aa7-bb8d-d1e2e2aeff2d"))
+
 end  # module ROCmDeviceLibs_jll

--- a/src/ROCmDeviceLibs_jll.jl
+++ b/src/ROCmDeviceLibs_jll.jl
@@ -6,5 +6,4 @@ import JLLWrappers
 
 JLLWrappers.@generate_main_file_header("ROCmDeviceLibs")
 JLLWrappers.@generate_main_file("ROCmDeviceLibs", UUID("873c0968-716b-5aa7-bb8d-d1e2e2aeff2d"))
-
 end  # module ROCmDeviceLibs_jll

--- a/src/wrappers/x86_64-w64-mingw32-cxx11.jl
+++ b/src/wrappers/x86_64-w64-mingw32-cxx11.jl
@@ -1,0 +1,14 @@
+export bitcode_path
+
+using Zlib_jll
+JLLWrappers.@generate_wrapper_header("ROCmDeviceLibs")
+JLLWrappers.@declare_file_product(bitcode_path)
+function __init__()
+    JLLWrappers.@generate_init_header(Zlib_jll)
+    JLLWrappers.@init_file_product(
+        bitcode_path,
+        "amdgcn/bitcode",
+    )
+
+    JLLWrappers.@generate_init_footer()
+end


### PR DESCRIPTION
Bitcode files are independent of OS and because I failed to build them from scratch for Windows 😓 I thought it is easier to just manually add Windows support this way.